### PR TITLE
Updates to improve operations with MANC data.

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ async def fetch_node_fields(req: Request):
     client = Client(server, dataset=version, token=token)
 
     neuron_types_query = 'MATCH(n:Neuron) WHERE EXISTS(n.type) RETURN DISTINCT n.type'
-    neuron_attributes_query = "CALL apoc.meta.data() YIELD label, property, type WITH ['Neuron'] as labels, property, type, label WHERE label in labels AND NOT type IN ['RELATIONSHIP', 'POINT'] RETURN property, type"
+    neuron_attributes_query = "MATCH (n: Neuron) UNWIND keys(n) AS property WITH DISTINCT property, apoc.meta.type(n[property]) AS type WHERE type <> 'PointValue' RETURN property, type"
     cell_body_fibers_query = "MATCH(n:Neuron) WHERE n.cellBodyFiber <> 'null' RETURN DISTINCT n.cellBodyFiber"
 
     neuron_types = fetch_custom(neuron_types_query)['n.type'].values.tolist()

--- a/main.py
+++ b/main.py
@@ -74,11 +74,50 @@ async def fetch_node_fields(req: Request):
     neuron_types_query = 'MATCH(n:Neuron) WHERE EXISTS(n.type) RETURN DISTINCT n.type'
     neuron_attributes_query = "MATCH (n: Neuron) UNWIND keys(n) AS property WITH DISTINCT property, apoc.meta.type(n[property]) AS type WHERE type <> 'PointValue' RETURN property, type"
     cell_body_fibers_query = "MATCH(n:Neuron) WHERE n.cellBodyFiber <> 'null' RETURN DISTINCT n.cellBodyFiber"
-
+    neuron_classes_query = 'MATCH(n:Neuron) WHERE EXISTS(n.class) RETURN DISTINCT n.class'
+    neuron_birthtime_query = 'MATCH(n:Neuron) WHERE EXISTS(n.birthtime) RETURN DISTINCT n.birthtime'
+    neuron_somaSide_query = 'MATCH(n:Neuron) WHERE EXISTS(n.somaSide) RETURN DISTINCT n.somaSide'
+    neuron_entryNerve_query = 'MATCH(n:Neuron) WHERE EXISTS(n.entryNerve) RETURN DISTINCT n.entryNerve'
+    neuron_exitNerve_query = 'MATCH(n:Neuron) WHERE EXISTS(n.exitNerve) RETURN DISTINCT n.exitNerve'
+    neuron_hemilineage_query = 'MATCH(n:Neuron) WHERE EXISTS(n.hemilineage) RETURN DISTINCT n.hemilineage'
+    neuron_longTract_query = 'MATCH(n:Neuron) WHERE EXISTS(n.longTract) RETURN DISTINCT n.longTract'
+    neuron_modality_query = 'MATCH(n:Neuron) WHERE EXISTS(n.modality) RETURN DISTINCT n.modality'
+    neuron_origin_query = 'MATCH(n:Neuron) WHERE EXISTS(n.origin) RETURN DISTINCT n.origin'
+    neuron_predictedNt_query = 'MATCH(n:Neuron) WHERE EXISTS(n.predictedNt) RETURN DISTINCT n.predictedNt'
+    neuron_serialMotif_query = 'MATCH(n:Neuron) WHERE EXISTS(n.serialMotif) RETURN DISTINCT n.serialMotif'
+    neuron_somaNeuromere_query = 'MATCH(n:Neuron) WHERE EXISTS(n.somaNeuromere) RETURN DISTINCT n.somaNeuromere'
+    neuron_somaSide_query = 'MATCH(n:Neuron) WHERE EXISTS(n.somaSide) RETURN DISTINCT n.somaSide'
+    neuron_subclass_query = 'MATCH(n:Neuron) WHERE EXISTS(n.subclass) RETURN DISTINCT n.subclass'
+    neuron_systematicType_query = 'MATCH(n:Neuron) WHERE EXISTS(n.systematicType) RETURN DISTINCT n.systematicType'
+    neuron_target_query = 'MATCH(n:Neuron) WHERE EXISTS(n.target) RETURN DISTINCT n.target'
+    
     neuron_types = client.fetch_custom(neuron_types_query)['n.type'].values.tolist()
     neuron_types_with_wildcard = get_wildcard(neuron_types)
+    neuron_classes = client.fetch_custom(neuron_classes_query)['n.class'].values.tolist()
+    neuron_classes_with_wildcard = get_wildcard(neuron_classes)
+    neuron_birthtimes = client.fetch_custom(neuron_birthtime_query)['n.birthtime'].values.tolist()
+    neuron_somaSides = client.fetch_custom(neuron_somaSide_query)['n.somaSide'].values.tolist()
+    neuron_entryNerve = client.fetch_custom(neuron_entryNerve_query)['n.entryNerve'].values.tolist()
+    neuron_entryNerve_with_wildcard = get_wildcard(neuron_entryNerve)
+    neuron_exitNerve = client.fetch_custom(neuron_exitNerve_query)['n.exitNerve'].values.tolist()
+    neuron_exitNerve_with_wildcard = get_wildcard(neuron_exitNerve)
+    neuron_hemilineage = client.fetch_custom(neuron_hemilineage_query)['n.hemilineage'].values.tolist()
+    neuron_hemilineage_with_wildcard = get_wildcard(neuron_hemilineage)    
+    neuron_longTract = client.fetch_custom(neuron_longTract_query)['n.longTract'].values.tolist()
+    neuron_modality = client.fetch_custom(neuron_modality_query)['n.modality'].values.tolist()
+    neuron_origin = client.fetch_custom(neuron_origin_query)['n.origin'].values.tolist()
+    neuron_origin_with_wildcard = get_wildcard(neuron_origin)
+    neuron_predictedNt = client.fetch_custom(neuron_predictedNt_query)['n.predictedNt'].values.tolist()    
+    neuron_somaSide = client.fetch_custom(neuron_somaSide_query)['n.somaSide'].values.tolist()
+    neuron_subclass = client.fetch_custom(neuron_subclass_query)['n.subclass'].values.tolist()
+    neuron_subclass_with_wildcard = get_wildcard(neuron_subclass)
+    neuron_systematicType = client.fetch_custom(neuron_systematicType_query)['n.systematicType'].values.tolist()
+    neuron_systematicType_with_wildcard = get_wildcard(neuron_systematicType)
+    neuron_target = client.fetch_custom(neuron_target_query)['n.target'].values.tolist()
+    neuron_target_with_wildcard = get_wildcard(neuron_target)
     cell_body_fibers = client.fetch_custom(cell_body_fibers_query)['n.cellBodyFiber'].values.tolist()
-
+    
+    
     neuron_attributes = client.fetch_custom(neuron_attributes_query)
     allRois = fetch_all_rois(client=client)
 
@@ -86,8 +125,36 @@ async def fetch_node_fields(req: Request):
     for property, type in neuron_attributes.itertuples(index=False):
         if property == "type":
             node_fields[property] = parse_node_fields(property, type, neuron_types_with_wildcard)
+        elif property == "class":
+            node_fields[property] = parse_node_fields(property, type, neuron_classes_with_wildcard)
+        elif property == "birthtime":
+            node_fields[property] = parse_node_fields(property, type, neuron_birthtimes)
+        elif property == "n.somaSide":
+            node_fields[property] = parse_node_fields(property, type, neuron_somaSides)
+        elif property == "entryNerve":
+            node_fields[property] = parse_node_fields(property, type, neuron_entryNerve_with_wildcard)
+        elif property == "exitNerve":
+            node_fields[property] = parse_node_fields(property, type, neuron_exitNerve_with_wildcard)
+        elif property == "hemilineage":
+            node_fields[property] = parse_node_fields(property, type, neuron_hemilineage_with_wildcard)
+        elif property == "longTract":
+            node_fields[property] = parse_node_fields(property, type, neuron_longTract)
+        elif property == "modality":
+            node_fields[property] = parse_node_fields(property, type, neuron_modality)
+        elif property == "modality":
+            node_fields[property] = parse_node_fields(property, type, neuron_origin_with_wildcard)
         elif property == "cellBodyFiber":
             node_fields[property] = parse_node_fields(property, type, cell_body_fibers)
+        elif property == "predictedNt":
+            node_fields[property] = parse_node_fields(property, type, neuron_predictedNt)
+        elif property == "somaSide":
+            node_fields[property] = parse_node_fields(property, type, neuron_somaSide)
+        elif property == "subclass":
+            node_fields[property] = parse_node_fields(property, type, neuron_subclass_with_wildcard)
+        elif property == "systematicType":
+            node_fields[property] = parse_node_fields(property, type, neuron_systematicType_with_wildcard)
+        elif property == "target":
+            node_fields[property] = parse_node_fields(property, type, neuron_target_with_wildcard)
         else:
             if parse_node_fields(property, type):
                 node_fields[property] = parse_node_fields(property, type)

--- a/main.py
+++ b/main.py
@@ -75,12 +75,12 @@ async def fetch_node_fields(req: Request):
     neuron_attributes_query = "MATCH (n: Neuron) UNWIND keys(n) AS property WITH DISTINCT property, apoc.meta.type(n[property]) AS type WHERE type <> 'PointValue' RETURN property, type"
     cell_body_fibers_query = "MATCH(n:Neuron) WHERE n.cellBodyFiber <> 'null' RETURN DISTINCT n.cellBodyFiber"
 
-    neuron_types = fetch_custom(neuron_types_query)['n.type'].values.tolist()
+    neuron_types = client.fetch_custom(neuron_types_query)['n.type'].values.tolist()
     neuron_types_with_wildcard = get_wildcard(neuron_types)
-    cell_body_fibers = fetch_custom(cell_body_fibers_query)['n.cellBodyFiber'].values.tolist()
+    cell_body_fibers = client.fetch_custom(cell_body_fibers_query)['n.cellBodyFiber'].values.tolist()
 
-    neuron_attributes = fetch_custom(neuron_attributes_query)
-    allRois = fetch_all_rois()
+    neuron_attributes = client.fetch_custom(neuron_attributes_query)
+    allRois = fetch_all_rois(client=client)
 
     node_fields = {}
     for property, type in neuron_attributes.itertuples(index=False):
@@ -106,7 +106,7 @@ async def fetch_edge_fields(req: Request):
     version = req['version']
     token = req['token']
     client = Client(server, dataset=version, token=token)
-    allRois = fetch_all_rois()
+    allRois = fetch_all_rois(client=client)
 
     edge_fields = {
         "weight": {

--- a/services/motif_search.py
+++ b/services/motif_search.py
@@ -30,7 +30,7 @@ def search_motif(data_server, data_version, auth_token, motif, lim):
     log.log_sketch(motif, lim)
 
     executor = NeuPrintExecutor(host=data_server, dataset=data_version, token=auth_token)
-    motif_source = nodes_and_edges_to_motif_string(motif, dataset=dataversion, token=auth_token)
+    motif_source = nodes_and_edges_to_motif_string(motif, data_server, dataset=data_version, token=auth_token)
     motif = Motif(enforce_inequality=True).from_motif(motif_source)
 
     cypher = executor.motif_to_cypher(motif=motif,

--- a/services/motif_search.py
+++ b/services/motif_search.py
@@ -30,7 +30,7 @@ def search_motif(data_server, data_version, auth_token, motif, lim):
     log.log_sketch(motif, lim)
 
     executor = NeuPrintExecutor(host=data_server, dataset=data_version, token=auth_token)
-    motif_source = nodes_and_edges_to_motif_string(motif)
+    motif_source = nodes_and_edges_to_motif_string(motif, dataset=dataversion, token=auth_token)
     motif = Motif(enforce_inequality=True).from_motif(motif_source)
 
     cypher = executor.motif_to_cypher(motif=motif,

--- a/utils/data_conversion.py
+++ b/utils/data_conversion.py
@@ -14,7 +14,7 @@ def nodes_and_edges_to_networkx(motif):
     return graph
 
 
-def nodes_and_edges_to_motif_string(motif, dataset, token):
+def nodes_and_edges_to_motif_string(motif, server, dataset, token):
     from neuprint import fetch_all_rois, Client
     """
     Converts Query Builder Mongo-esque parameters to dotmotif query format

--- a/utils/data_conversion.py
+++ b/utils/data_conversion.py
@@ -14,18 +14,19 @@ def nodes_and_edges_to_networkx(motif):
     return graph
 
 
-def nodes_and_edges_to_motif_string(motif):
-    from neuprint import fetch_all_rois
+def nodes_and_edges_to_motif_string(motif, dataset, token):
+    from neuprint import fetch_all_rois, Client
     """
     Converts Query Builder Mongo-esque parameters to dotmotif query format
     """
 
+    client = Client(server, dataset=dataset, token=token)
     # print(motif)
     edges = motif['edges']
     nodes = motif['nodes']
     output = "\n "
 
-    rois = fetch_all_rois()
+    rois = fetch_all_rois(client=client)
     # First list every edge like A -> B [weight > x]
     for edge in edges:
         edge_str = edge['label']

--- a/utils/data_conversion.py
+++ b/utils/data_conversion.py
@@ -109,7 +109,7 @@ def parse_node_fields(property, type, values=None):
                 "operators": ["equal"]
             }
     else:
-        if property == "type":
+        if property in ["type", "birthtime", "class", "someSide", "entryNerve", "exitNerve", "hemilineage", "longTract", "modality", "origin", "predictedNt", "serialMotif", "somaNeuromere", "somaSide", "subclass", "systematicType", "target"]:
             return {
                 "label": property,
                 "type": "select",


### PR DESCRIPTION
We had to replace the neuron_attributes_query to improve the response time, otherwise the queries would time out on the MANC dataset. More importantly, we need to make sure that the neuprint_python client was passed to each request, because if it is not, it is created for the first dataset that is requested and cached. This resulted in all requests being run against the first dataset as opposed to the requested dataset. Finally, we added a bunch of new fields to the MANC dataset that needed to be added to the data_conversion functions.